### PR TITLE
Add fixture helper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,4 +15,22 @@ scratch. But after trying to make heads and tails of them
 when faced with bugs, I ended-up finding simpler to start
 over.
 
+Using dockerfixtures with pytest
+================================
 
+To spawn a container in your tests, proceed as follow:
+
+
+.. code:: Python
+
+    from dockerfixtures import Image, Container
+    import pytest
+
+
+    @pytest.fixture(scope='session')
+    def some_image():
+        return image.Image('postgres', tags='12')
+       
+    @pytest.fixture(scope='session')
+    def some_container_fixture(some_image):
+        yield from container.fixture(some_image)

--- a/README.rst
+++ b/README.rst
@@ -21,16 +21,52 @@ Using dockerfixtures with pytest
 To spawn a container in your tests, proceed as follow:
 
 
-.. code:: Python
+.. code-block:: Python
 
-    from dockerfixtures import Image, Container
+    from dockerfixtures import image, container
     import pytest
 
 
     @pytest.fixture(scope='session')
-    def some_image():
+    def pg_image() -> image.Image:
         return image.Image('postgres', tags='12')
-       
-    @pytest.fixture(scope='session')
-    def some_container_fixture(some_image):
+
+    @pytest.fixture(scope='function')
+    def pg_container(pg_image: image.Image) -> container.Container:
         yield from container.fixture(some_image)
+
+    # If you don't need to reuse the image
+
+    @pytest.fixture(scope='session')
+    def pg_container() -> container.Container:
+        some_image = image.Image('postgres', tags='12')
+        yield from container.fixture(some_image)
+
+
+Why not a pytest plugin ?
+=========================
+
+Other implementation of this have been provinding a pytest
+plugin, so you might wonder why this one doesn't ?
+
+First reason is I have not looked into it that much, yet.
+
+But anyhow, you would still need to import the
+``dockerfixtures.image`` module. So I am not very sure what the
+benefits would be ?
+
+Also I found those plugins to provide somewhat bizarre API, for
+example to define the fixtures' scope. I haven't looked into
+why they do that, yet. Here there are no surprises, a container
+fixture looks like any other fixture.
+
+Pytest plugins are global: they have to be imported in your
+`top-level`_ ``conftest.py`` (see note). I think it is good
+practice to keep your tests properly partitioned based on their
+external dependencies. It can help split workload if the need
+arises. In a collaborative environment, having to import
+``dockerfixtures``, may help prevent breaking that partitioning
+during reviews.
+
+
+.. _top-level: https://docs.pytest.org/en/latest/writing_plugins.html#requiring-loading-plugins-in-a-test-module-or-conftest-file

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -120,7 +120,7 @@ def image_metadata(docker_image):
 @pytest.fixture
 def docker_image():
     image = mock.Mock()
-    image.attrs = {'ExposedPorts': {'1234/tcp': {}},}
+    image.attrs = {'ExposedPorts': {'1234/tcp': {}}, }
     return image
 
 

--- a/tests/unit/container/test_fixture.py
+++ b/tests/unit/container/test_fixture.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; -*-
+from dockerfixtures import container, image
+
+
+def test_fixture_forwards_arguments(mocker):
+    # Given
+    Container = mocker.patch('dockerfixtures.container.Container')
+    env = dict()
+    img = image.Image('')
+    interval = 567.8
+    maxwait = 123.4
+    opts = dict()
+    ports = ((5432, 'tcp', ), (5432, 'unix', ), )
+
+    # When
+    for _ in container.fixture(img,
+                           *ports,
+                           environment=env,
+                           max_wait=maxwait,
+                           options=opts,
+                           readyness_poll_interval=interval,
+                           ):
+        pass
+
+    # Then
+    Container.assert_called_once_with(img, options=opts, environment=env)
+    Container().__enter__().wait.assert_called_once_with(*ports,
+                                                         readyness_poll_interval=interval,
+                                                         max_wait=maxwait)
+
+
+# vim: et:sw=4:syntax=python:ts=4:

--- a/tests/unit/container/test_fixture.py
+++ b/tests/unit/container/test_fixture.py
@@ -13,14 +13,13 @@ def test_fixture_forwards_arguments(mocker):
     ports = ((5432, 'tcp', ), (5432, 'unix', ), )
 
     # When
-    for _ in container.fixture(img,
+    next(container.fixture(img,
                            *ports,
                            environment=env,
                            max_wait=maxwait,
                            options=opts,
                            readyness_poll_interval=interval,
-                           ):
-        pass
+                           ))
 
     # Then
     Container.assert_called_once_with(img, options=opts, environment=env)


### PR DESCRIPTION
Lowers the amount of boilerplate code required to implement a pytest fixture.

Document how to implement fixtures for pytest.