### PR TITLE
Make run & wait behavior similar

### DIFF
--- a/tests/unit/container/test_container.py
+++ b/tests/unit/container/test_container.py
@@ -19,7 +19,7 @@ def test_container_image_attribute_is_set():
 def test_container_environment_inherits_image_environment(dummy_env, client, running_container):
     # Given
     image = Image('', environment=dummy_env)
-    cntr = Container(image, startup_poll_interval=0.0)
+    cntr = Container(image, max_wait=1.0)
 
     # When
     cntr.run(dockerclient=client)
@@ -59,7 +59,7 @@ def test_container_as_a_context_manager(client, running_container):
     image = Image('')
 
     # When
-    with Container(image, dockerclient=client, max_wait=0):
+    with Container(image, dockerclient=client, max_wait=1.0):
         pass
 
     assert client.containers.run.called
@@ -82,7 +82,7 @@ def test_container_as_a_context_manager_raises_if_no_client():
 def test_container_as_a_context_manager_reraises_exception(client, running_container):
     # Given
     image = Image('')
-    cntr = Container(image, dockerclient=client, max_wait=0)
+    cntr = Container(image, dockerclient=client, max_wait=1.0)
 
     # Ensure
     with pytest.raises(Exception, match='^1234$'):

--- a/tests/unit/container/test_container_run.py
+++ b/tests/unit/container/test_container_run.py
@@ -13,7 +13,7 @@ def test_container_paused_then_running(mocker, client, container_paused_after_1s
     poll_interval = 10.0
     image = Image('')
     cntr = Container(image, max_wait=2, startup_poll_interval=poll_interval)
-    time = mocker.patch('dockerfixtures.container.time')
+    sleep = mocker.patch('dockerfixtures.container.time.sleep')
 
     # When
     result = cntr.run(dockerclient=client)
@@ -22,7 +22,7 @@ def test_container_paused_then_running(mocker, client, container_paused_after_1s
     # call count is 2 because reload is call one last time before raising
     assert container_paused_after_1st_reload.id == result
     assert container_paused_after_1st_reload.reload.call_count == 2
-    time.sleep.assert_called_once_with(poll_interval)
+    sleep.assert_called_once_with(poll_interval)
 
 
 def test_container_run_raises_runtime_error_when_exited(client,
@@ -64,7 +64,7 @@ def test_container_running_after_second_reload(mocker, client, container_running
     poll_interval = 10.0
     image = Image('')
     cntr = Container(image, startup_poll_interval=poll_interval)
-    time = mocker.patch('dockerfixtures.container.time')
+    sleep = mocker.patch('dockerfixtures.container.time.sleep')
 
     # When
     result = cntr.run(dockerclient=client)
@@ -72,7 +72,7 @@ def test_container_running_after_second_reload(mocker, client, container_running
     # Then
     assert container_running_after_2_reload.id == result
     assert container_running_after_2_reload.reload.call_count == 2
-    time.sleep.assert_called_once_with(poll_interval)
+    sleep.assert_called_once_with(poll_interval)
 
 
 def test_container_run_raises_image_not_found_when_registry_says_so(mocker, client):
@@ -92,7 +92,7 @@ def test_container_run_raises_runtime_warning_when_unkwown_status(client,
     """
     # Given
     image = Image('')
-    cntr = Container(image)
+    cntr = Container(image, startup_poll_interval=0.0)
 
     # Ensure
     with pytest.warns(RuntimeWarning):
@@ -105,8 +105,11 @@ def test_container_run_raises_runtime_warning_when_unkwown_status(client,
 
 def test_container_run_times_out(mocker, client, container):
     # Given
-    cntr = Container(Image(''), max_wait=1, dockerclient=client)
-    mocker.patch('dockerfixtures.container.time')  # bypass time.sleep()
+    cntr = Container(Image(''),
+                     dockerclient=client,
+                     max_wait=0.000000001,
+                     startup_poll_interval=0.0)
+    mocker.patch('dockerfixtures.container.time.sleep')  # bypass time.sleep()
 
     # Ensure
     with pytest.raises(TimeOut):
@@ -114,6 +117,6 @@ def test_container_run_times_out(mocker, client, container):
         cntr.run()
 
     # Then
-    assert container.reload.call_count > 0
+    assert container.reload.call_count == 0
 
 # vim: et:sw=4:syntax=python:ts=4:


### PR DESCRIPTION
Both methods now are allotted a max amount of time to wait and the number of retries can be approximated using a polling wait interval.

Also lowered the complexity of run() a tiny bit.